### PR TITLE
Update example_outbound_swml.json

### DIFF
--- a/example_outbound_swml.json
+++ b/example_outbound_swml.json
@@ -9,8 +9,7 @@
         },
         {
           "connect": {
-            "to": "%{vars.userVariables.destination_number}",
-            "from": "+1NXXNXXXXXX"
+            "to": "%{vars.userVariables.destination_number}"
           }
         }
       ]


### PR DESCRIPTION
This is a required change for my update to app.py. My code change creates a SWML bin copying this file, but if you have a placeholder "from" number the calls will fail. Since from is optional, this version works right away, just doesn't automatically set the from number.

## Summary by Sourcery

Enhancements:
- Remove the placeholder "from" number from example_outbound_swml.json to prevent call failures when no sender number is set